### PR TITLE
fix: typo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-starlette=0.37.2
-googlemaps=4.10.0
+starlette==0.37.2
+googlemaps==4.10.0


### PR DESCRIPTION
Fixed the typo in the requirements file. You used the assignment instead of the comparison operator.